### PR TITLE
Fix rxjs for TypeScript >= 2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@angular/platform-browser-dynamic": "~4.0.0",
     "@angular/router": "~4.0.0",
     "core-js": "^2.4.1",
-    "rxjs": "5.0.1",
+    "rxjs": "5.4.2",
     "zone.js": "0.8.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Rxjs was failing due to [this issue](https://stackoverflow.com/questions/44793859/rxjs-subject-d-ts-error-class-subjectt-incorrectly-extends-base-class-obs) so I fixed the version used :)

No more 
```
Class 'Subject<T>' incorrectly extends base class 'Observable<T>'
```

 👍
 